### PR TITLE
Function to retrieve driver name

### DIFF
--- a/adminer/include/driver.inc.php
+++ b/adminer/include/driver.inc.php
@@ -11,6 +11,15 @@ function add_driver($id, $name) {
 	$drivers[$id] = $name;
 }
 
+/** Get driver name
+* @param string
+* @return string
+*/
+function get_driver($id) {
+	global $drivers;
+	return $drivers[$id];
+}
+
 /*abstract*/ class Min_SQL {
 	var $_conn;
 


### PR DESCRIPTION
Plugins cannot access `$drivers` global after compilation. This would allow display of the nice driver name without having to know the shrunken variable name.

Original: https://github.com/vrana/adminer/pull/438