### PR TITLE
Enable regular expressions when searching data

### DIFF
--- a/adminer/db.inc.php
+++ b/adminer/db.inc.php
@@ -59,9 +59,13 @@ if ($adminer->homepage()) {
 				echo "<input type='search' name='query' value='" . h($_POST["query"]) . "'>";
 				echo script("qsl('input').onkeydown = partialArg(bodyKeydown, 'search');", "");
 				echo " <input type='submit' name='search' value='" . lang('Search') . "'>\n";
+				if ($adminer->operator_regexp !== null) {
+					echo "<p><label><input type='checkbox' name='regexp' value='1'" . (empty($_POST['regexp']) ? '' : ' checked') . '>' . lang('as a regular expression') . '</label>';
+					echo doc_link(array('sql' => 'regexp.html', 'pgsql' => 'functions-matching.html#FUNCTIONS-POSIX-REGEXP')) . "</p>\n";
+				}
 				echo "</div></fieldset>\n";
 				if ($_POST["search"] && $_POST["query"] != "") {
-					$_GET["where"][0]["op"] = "LIKE %%";
+					$_GET["where"][0]["op"] = $adminer->operator_regexp === null || empty($_POST['regexp']) ? "LIKE %%" : $adminer->operator_regexp;
 					search_tables();
 				}
 			}

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -206,6 +206,7 @@ if (isset($_GET["mongo"])) {
 		}
 
 		$operators = array("=");
+		$operator_regexp = null;
 
 	} elseif (class_exists('MongoDB\Driver\Manager')) {
 		class Min_DB {
@@ -576,6 +577,7 @@ if (isset($_GET["mongo"])) {
 			"(date)<=",
 		);
 
+		$operator_regexp = 'regex';
 	}
 
 	function table($idf) {
@@ -732,11 +734,12 @@ if (isset($_GET["mongo"])) {
 	}
 
 	function driver_config() {
-		global $operators;
+		global $operators, $operator_regexp;
 		return array(
 			'possible_drivers' => array("mongo", "mongodb"),
 			'jush' => "mongo",
 			'operators' => $operators,
+			'operator_regexp' => $operator_regexp,
 			'functions' => array(),
 			'grouping' => array(),
 			'edit_functions' => array(array("json")),

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1161,6 +1161,7 @@ if (!defined("DRIVER")) {
 			'unsigned' => array("unsigned", "zerofill", "unsigned zerofill"), ///< @var array number variants
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "REGEXP", "IN", "FIND_IN_SET", "IS NULL", "NOT LIKE", "NOT REGEXP", "NOT IN", "IS NOT NULL", "SQL"), ///< @var array operators used in select
 			'functions' => array("char_length", "date", "from_unixtime", "unix_timestamp", "lower", "round", "floor", "ceil", "sec_to_time", "time_to_sec", "upper"), ///< @var array functions used in select
+			'operator_regexp' => 'REGEXP',
 			'grouping' => array("avg", "count", "count distinct", "group_concat", "max", "min", "sum"), ///< @var array grouping functions used in select
 			'edit_functions' => array( ///< @var array of array("$type|$type2" => "$function/$function2") functions used in editing, [0] - edit and insert, [1] - edit only
 				array(

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -909,7 +909,8 @@ AND typelem = 0"
 			'types' => $types,
 			'structured_types' => $structured_types,
 			'unsigned' => array(),
-			'operators' => array("=", "<", ">", "<=", ">=", "!=", "~", "!~", "LIKE", "LIKE %%", "ILIKE", "ILIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL"), // no "SQL" to avoid CSRF
+			'operators' => array("=", "<", ">", "<=", ">=", "!=", "~", "~*", "!~", "!~*", "LIKE", "LIKE %%", "ILIKE", "ILIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL"), // no "SQL" to avoid CSRF
+			'operator_regexp' => '~*',
 			'functions' => array("char_length", "lower", "round", "to_hex", "to_timestamp", "upper"),
 			'grouping' => array("avg", "count", "count distinct", "max", "min", "sum"),
 			'edit_functions' => array(

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -93,11 +93,13 @@ $types = $config['types'];
 $structured_types = $config['structured_types'];
 $unsigned = $config['unsigned'];
 $operators = $config['operators'];
+$operator_regexp = isset($config['operator_regexp']) && in_array($config['operator_regexp'], $operators) ? $config['operator_regexp'] : null;
 $functions = $config['functions'];
 $grouping = $config['grouping'];
 $edit_functions = $config['edit_functions'];
 if ($adminer->operators === null) {
 	$adminer->operators = $operators;
+	$adminer->operator_regexp = $operator_regexp;
 }
 
 define("SERVER", $_GET[DRIVER]); // read from pgsql=localhost


### PR DESCRIPTION
Allows use of the database-specific regex operator and pattern syntax when searching multiple tables. This can greatly improve the relevance of results, e.g. searching for whole words in MySQL with a pattern such as `[[:<:]]example[[:>:]]`.

![The interface](https://user-images.githubusercontent.com/28617290/181157170-a93e469b-8394-4230-895b-23f9effda321.png)

Original: https://github.com/vrana/adminer/pull/430

---
I need someone more knowledgeable in Postgres and Mongo to test this feature.