### PR TITLE
Fixed a bug that when using pgsql, adminer/editer search tries to access the index of string for string. 

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -214,7 +214,7 @@ if (isset($_GET["pgsql"])) {
 
 		function convertSearch($idf, $val, $field) {
 			return (preg_match('~char|text'
-					. (!preg_match('~LIKE~', $val["op"]) ? '|date|time(stamp)?|boolean|uuid|' . number_type() : '')
+					. (!preg_match('~LIKE~', $val) ? '|date|time(stamp)?|boolean|uuid|' . number_type() : '')
 					. '~', $field["type"])
 				? $idf
 				: "CAST($idf AS text)"


### PR DESCRIPTION
I happen error following.

```
[Tue Jul 11 19:51:02 2023] PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in /Users/xxx/Desktop/editor.php:450
Stack trace:
#0 /Users/xxx/Desktop/editor.php(1199): Min_Driver->convertSearch()
#1 /Users/xxx/Desktop/editor.php(1490): Adminer->selectSearchProcess()
#2 /Users/xxx/Desktop/adminer.php(40): include('...')
#3 {main}
  thrown in /Users/xxx/Desktop/editor.php on line 450
```