### PR TITLE
No-verify plugin breaks others

### DIFF
--- a/plugins/version-noverify.php
+++ b/plugins/version-noverify.php
@@ -7,10 +7,9 @@
 * @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
 */
 class AdminerVersionNoverify {
-	
+
 	function head() {
 		echo script("verifyVersion = function () {};");
-		return true;
 	}
-	
+
 }


### PR DESCRIPTION
Does not need to block other plugins from using the `head()` method.

All it does is override one JS function, which isn't referenced until [much later in the generated document](https://github.com/adminerevo/adminerevo/blob/2be76a970ae461877e5504e6e6f7c784e3ec53ea/adminer/include/design.inc.php#L57), so has no need to block other PHP.