### PR TITLE
Remove undefined variable removed by #7442183 (for IE9 compatibility)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -236,7 +236,7 @@ class Adminer {
 		if (!$failed && ($warnings = $driver->warnings())) {
 			$id = "warnings";
 			$return = ", <a href='#$id'>" . lang('Warnings') . "</a>" . script("qsl('a').onclick = partial(toggle, '$id');", "")
-				. "$return<div id='$id' class='hidden'>\n$warnings</div>\n"
+				. "<div id='$id' class='hidden'>\n$warnings</div>\n"
 			;
 		}
 		$links = [


### PR DESCRIPTION
Remove variable, that was defined in code removed by 7442183.