### PR TITLE
Fixes plugin edit-foreign.php

### DIFF
--- a/plugins/edit-foreign.php
+++ b/plugins/edit-foreign.php
@@ -25,13 +25,17 @@ class AdminerEditForeign {
 				$target = $foreignKey["table"];
 				$id = $foreignKey["target"][0];
 				$options = &$values[$target][$id];
-				if (!$options) {
+				if ($options === false) {
+					return;
+				}
+				if (!isset($options)) {
 					$column = idf_escape($id);
 					if (preg_match('~binary~', $field["type"])) {
 						$column = "HEX($column)";
 					}
 					$options = array("" => "") + get_vals("SELECT $column FROM " . table($target) . " ORDER BY 1" . ($this->_limit ? " LIMIT " . ($this->_limit + 1) : ""));
 					if ($this->_limit && count($options) - 1 > $this->_limit) {
+						$options = false;
 						return;
 					}
 				}


### PR DESCRIPTION
When a table has a FK multiple times on a single table and the limit is exceeded, the select will no longer show for every field but the first for that target table.

This made it impossible to save such tables correctly.