### PR TITLE
Skip dump of generated columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /adminer*.php
 /editor*.php
 /vendor/
+/.idea

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -880,6 +880,7 @@ class Adminer {
 						}
 						foreach ($row as $key => $val) {
 							if (isset($generatedKeys[$key])) {
+								unset($row[$key]);
 								continue;
                             }
 							$field = $fields[$key];

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -850,6 +850,7 @@ class Adminer {
 				$insert = "";
 				$buffer = "";
 				$keys = array();
+				$generatedKeys = array();
 				$suffix = "";
 				$fetch_function = ($table != '' ? 'fetch_assoc' : 'fetch_row');
 				while ($row = $result->$fetch_function()) {
@@ -857,6 +858,10 @@ class Adminer {
 						$values = array();
 						foreach ($row as $val) {
 							$field = $result->fetch_field();
+							if (!empty($fields[$field->name]['generated'])) {
+								$generatedKeys[$field->name] = true;
+								continue;
+                            }
 							$keys[] = $field->name;
 							$key = idf_escape($field->name);
 							$values[] = "$key = VALUES($key)";
@@ -874,6 +879,9 @@ class Adminer {
 							$insert = "INSERT INTO " . table($table) . " (" . implode(", ", array_map('idf_escape', $keys)) . ") VALUES";
 						}
 						foreach ($row as $key => $val) {
+							if (isset($generatedKeys[$key])) {
+								continue;
+                            }
 							$field = $fields[$key];
 							$row[$key] = ($val !== null
 								? unconvert_field($field, preg_match(number_type(), $field["type"]) && !preg_match('~\[~', $field["full_type"]) && is_numeric($val) ? $val : q(($val === false ? 0 : $val)))

--- a/todo.txt
+++ b/todo.txt
@@ -20,7 +20,6 @@ Joining tables - PRIMARY KEY (table, joining)
 Rank, Tree structure
 
 MySQL:
-Generated columns (MySQL >= 5.7.6)
 Data longer than max_allowed_packet can be sent by mysqli_stmt_send_long_data()
 
 MariaDB:


### PR DESCRIPTION
Fix for issue #81

A dump should not contain generated columns.

Testing instructions:

Create a table with generated column:
```
CREATE TABLE `users_test` (
  `id` int unsigned NOT NULL AUTO_INCREMENT,
  `first_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
  `middle_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `last_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
  `full_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (trim(concat_ws(_utf8mb4' ',`first_name`,`middle_name`,`last_name`))) STORED,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

Insert a data, see that `full_name` column will be auto-populated:
```
INSERT INTO `users_test` (`first_name`, `middle_name`, `last_name`)
VALUES ('first', 'middle', 'last');
```

Export data, see `full_name` column data. Try to re-import data into empty table, see error.

Apply patch, export data, re-import data into empty table, no errors.