### PR TITLE
PHP 8.3 error suppression

### DIFF
--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -1,6 +1,6 @@
 <?php
 function adminer_errors($errno, $errstr) {
-	return !!preg_match('~^(Trying to access array offset on value of type null|Undefined array key)~', $errstr);
+	return !!preg_match('~^(Trying to access array offset on( value of type)? null|Undefined array key)~', $errstr);
 }
 
 error_reporting(6135); // errors and warnings

--- a/compile.php
+++ b/compile.php
@@ -251,7 +251,8 @@ function php_shrink($input) {
 		if (!is_array($token)) {
 			$token = array(0, $token);
 		}
-		if ($tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
+		if (!is_null($tokens[$i+2])
+			&& $tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
 			&& strlen(add_apo_slashes($tokens[$i+3][1])) < strlen($tokens[$i+3][1]) + 3
 		) {
 			$tokens[$i+2] = array(T_ECHO, 'echo');


### PR DESCRIPTION
PHP 8.3 has shortened the array access on null error message to "Trying to access array offset on null". This commit changes the regular expression used to circumvent errors.