### PR TITLE
fix: rollback border styles from original adminer

### DIFF
--- a/adminer/static/default.css
+++ b/adminer/static/default.css
@@ -24,7 +24,7 @@ code { background: #eee; }
 tbody tr:hover td, tbody tr:hover th { background: #eee; }
 pre { margin: 1em 0 0; }
 pre, textarea { font: 100%/1.25 monospace; }
-input, button { vertical-align: middle; border-radius: 5px; padding: 2px; border-width: 1px; }
+input, button { vertical-align: middle; padding: 2px; border-width: 1px; }
 input.default { box-shadow: 1px 1px 1px #777; }
 input.required { box-shadow: 1px 1px 1px red; }
 input.maxlength { box-shadow: 1px 1px 1px red; }


### PR DESCRIPTION
Issue #111 

I removed the `border-radius` rule that was applied without actually specifying a `border` for `inputs` and `buttons`. 

Previously
![image](https://github.com/adminerevo/adminerevo/assets/4358071/40d7e935-7286-423b-b7af-ae13ca8e809a)

Now
![image](https://github.com/adminerevo/adminerevo/assets/4358071/51967ef6-907c-4639-9c09-2a477571ce4c)
 