### PR TITLE
Restore latest version check

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -993,6 +993,7 @@ class Adminer {
 		?>
 <h1>
 <?php echo $this->name(); ?> <span class="version"><?php echo $VERSION; ?></span>
+<a href="https://download.adminerevo.org/latest/adminer/"<?php echo target_blank(); ?> id="version"><?php echo (version_compare($VERSION, $_COOKIE["adminer_version"]) < 0 ? h($_COOKIE["adminer_version"]) : ""); ?></a>
 </h1>
 <?php
 		if ($missing == "auth") {

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -33,7 +33,7 @@ if (isset($_GET["file"])) {
 if ($_GET["script"] == "version") {
 	$fp = file_open_lock(get_temp_dir() . "/adminer.version");
 	if ($fp) {
-		file_write_unlock($fp, serialize(array("signature" => $_POST["signature"], "version" => $_POST["version"])));
+		file_write_unlock($fp, serialize(array("version" => $_POST["version"])));
 	}
 	exit;
 }

--- a/adminer/include/design.inc.php
+++ b/adminer/include/design.inc.php
@@ -35,21 +35,9 @@ function page_header($title, $error = "", $breadcrumb = array(), $title2 = "") {
 <body class="<?php echo lang('ltr'); ?> nojs <?php echo $GLOBALS['project']; ?>">
 <?php
 	$filename = get_temp_dir() . "/adminer.version";
-	if (!$_COOKIE["adminer_version"] && function_exists('openssl_verify') && file_exists($filename) && filemtime($filename) + 86400 > time()) { // 86400 - 1 day in seconds
+	if (!$_COOKIE["adminer_version"] && file_exists($filename) && filemtime($filename) + 86400 > time()) { // 86400 - 1 day in seconds
 		$version = unserialize(file_get_contents($filename));
-		$public = "-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwqWOVuF5uw7/+Z70djoK
-RlHIZFZPO0uYRezq90+7Amk+FDNd7KkL5eDve+vHRJBLAszF/7XKXe11xwliIsFs
-DFWQlsABVZB3oisKCBEuI71J4kPH8dKGEWR9jDHFw3cWmoH3PmqImX6FISWbG3B8
-h7FIx3jEaw5ckVPVTeo5JRm/1DZzJxjyDenXvBQ/6o9DgZKeNDgxwKzH+sw9/YCO
-jHnq1cFpOIISzARlrHMa/43YfeNRAm/tsBXjSxembBPo7aQZLAWHmaj5+K19H10B
-nCpz9Y++cipkVEiKRGih4ZEvjoFysEOdRLj6WiD/uUNky4xGeA6LaJqh5XpkFkcQ
-fQIDAQAB
------END PUBLIC KEY-----
-";
-		if (openssl_verify($version["version"], base64_decode($version["signature"]), $public) == 1) {
-			$_COOKIE["adminer_version"] = $version["version"]; // doesn't need to send to the browser
-		}
+		$_COOKIE["adminer_version"] = $version["version"]; // doesn't need to send to the browser
 	}
 	?>
 <script<?php echo nonce(); ?>>
@@ -133,8 +121,8 @@ function csp() {
 	return array(
 		array(
 			"script-src" => "'self' 'unsafe-inline' 'nonce-" . get_nonce() . "' 'strict-dynamic'", // 'self' is a fallback for browsers not supporting 'strict-dynamic', 'unsafe-inline' is a fallback for browsers not supporting 'nonce-'
-			"connect-src" => "'self'",
-			"frame-src" => "https://www.adminer.org",
+			"connect-src" => "'self' https://api.github.com/repos/adminerevo/adminerevo/releases/latest",
+			"frame-src" => "'self'",
 			"object-src" => "'none'",
 			"base-uri" => "'none'",
 			"form-action" => "'self'",

--- a/adminer/static/functions.js
+++ b/adminer/static/functions.js
@@ -101,27 +101,22 @@ function cookie(assign, days) {
 */
 function verifyVersion(current, url, token) {
 	cookie('adminer_version=0', 1);
-	var iframe = document.createElement('iframe');
-	iframe.src = 'https://www.adminer.org/version/?current=' + current;
-	iframe.frameBorder = 0;
-	iframe.marginHeight = 0;
-	iframe.scrolling = 'no';
-	iframe.style.width = '7ex';
-	iframe.style.height = '1.25em';
-	if (window.postMessage && window.addEventListener) {
-		iframe.style.display = 'none';
-		addEventListener('message', function (event) {
-			if (event.origin == 'https://www.adminer.org') {
-				var match = /version=(.+)/.exec(event.data);
-				if (match) {
-					cookie('adminer_version=' + match[1], 1);
-					ajax(url + 'script=version', function () {
-					}, event.data + '&token=' + token);
-				}
+	ajax('https://api.github.com/repos/adminerevo/adminerevo/releases/latest', function (request) {
+		var data = window.JSON ? JSON.parse(request.responseText) : eval('(' + request.responseText + ')');
+		version = data.tag_name.replace(/[^\d.]/g, '');
+
+		if (version) {
+			cookie('adminer_version=' + version, 1);
+			var data = 'version=' + version;
+			ajax(url + 'script=version', function () {
+			}, data + '&token=' + token);
+
+			if (version != current) {
+				qs('#version').innerText = version;
 			}
-		}, false);
-	}
-	qs('#version').appendChild(iframe);
+		}
+
+	});
 }
 
 /** Get value of select


### PR DESCRIPTION
@LionelLaffineur - There are lots of ways to do this so if you don't like this approach, please let me know and I can revise, but here is my thinking on a few things.

<img width="205" alt="image" src="https://github.com/adminerevo/adminerevo/assets/871211/3cf88dbd-423d-440f-aff9-05b78fc5e82f">

1) I went with parsing https://api.github.com/repos/adminerevo/adminerevo/releases/latest to save you needing to manually update anything.

2) I got rid of the old iframe injection which no longer makes sense given the way I am now just grabbing the version number, rather than a complete `<a href` link to the download URL as it was done before.

3) I removed the `openssl_verify` check on the locally written adminer.version file because we're no longer populating it with data from the `postMessage` returned from the old https://www.adminer.org/version/?current=4.7.2 - it used to take the signature from there and save it to adminer.version which could later be verified. Do we really need that now? Honestly, I am not completely sure of the need to even save the version to adminer.version - it is there as a backup to `$_COOKIE['adminer_version']`, but both are considered expired after 24 hours anyway, so seems a bit weird to me. Still, I have kept the file for now, although now it only contains the version number (no signature).

4) Because the version is requested via JS and not PHP, the first time adminer is loaded when the cookie and adminer.version are expired, the linked version number is presented based on a simple `version != current` check. Subsequent loads are handled by PHP's `version_compare()` which can handle versions with `-dev` etc. This really just means that currently, on initial load of 4.8.4-dev, a linked 4.8.3 will display. On subsequent loads, it won't display because it will properly be determined that 4.8.3 is older that 4.8.4-dev. I think this is an OK compromise, but if you don't like, I think there are two ways around this - one being to implement a `version_compare()` in JS (eg: https://github.com/locutusjs/locutus/blob/aa2751437a92cc1b33204b5e1252e8ef899206ad/src/php/info/version_compare.js#L1), or I could pull the version request logic in from JS to PHP so it's available to PHP's `version_compare()` check here: 
```<a href="https://download.adminerevo.org/latest/adminer/"<?php echo target_blank(); ?> id="version"><?php echo (version_compare($VERSION, $_COOKIE["adminer_version"]) < 0 ? h($_COOKIE["adminer_version"]) : ""); ?></a>```
I stayed with the JS approach because I didn't want to have to get into curl fallbacks to `file_get_contents()`, `fopen()` etc, given that adminer doesn't currently use these. Also, I went with adminer's `ajax()` JS function rather than `fetch()`. It feels ugly (especially given its use of `eval()`, but I thought for now, sticking close to the original approaches made more sense).

Please let me know what you think of my decisions, especially those around the signature in adminer.version - is there a good reason for this that I am overlooking? Even if someone did mess with the locally saved adminer.version, what could they actually do that is malicious given that we only use it show the linked version number - it has no way to modify the link itself?