### PR TITLE
Fix multiple "Copy to clipboard" on page

### DIFF
--- a/adminer/static/functions.js
+++ b/adminer/static/functions.js
@@ -884,21 +884,21 @@ function findDefaultSubmit(el) {
  * @param HTMLElement
  */
 function setupCopyToClipboard(document) {
-	var node = document.querySelector("a.copy-to-clipboard");
-	if (node) {
-		node.addEventListener("click", function() {
+	var node = document.querySelectorAll("a.copy-to-clipboard");
+	node.forEach(function(element) {
+		element.addEventListener("click", function() {
 			var nodeSql = document.querySelector("code.copy-to-clipboard");
 			if (nodeSql == null || nodeSql == undefined) {
 				nodeSql = document.querySelector("textarea.sqlarea");
 			}
 			if (nodeSql != null && nodeSql != undefined) {
-				if (node.classList.contains('expand')) {
-					document.getElementById(node.getAttribute('data-expand-id')).classList.remove("hidden");
+				if (element.classList.contains('expand')) {
+					document.getElementById(element.getAttribute('data-expand-id')).classList.remove("hidden");
 				}
 				copyToClipboard(nodeSql);
 			}
 		});
-	}
+	});
 }
 
 /** Copy element's content in clipboard


### PR DESCRIPTION
Minor fix. 
If there is more than one link with class "copy-to-clipboard" on a page, only the first one found works and the others are inactive.

On this image, here only the icon next to "SQL command" is functional, but the link in the footer next to "Edit" no longer copies the command.
![Screenshot 2024-04-10 062903](https://github.com/adminerevo/adminerevo/assets/3526195/97a484b9-5ccf-4d71-b7e4-6c00d3888003)
