### PR TITLE
Removed check to reject server URL path added in version 4.8.4.

### DIFF
--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -35,12 +35,6 @@ function validate_server_input() {
 		auth_error(lang('Invalid server or credentials.'));
 	}
 
-	// Allow only host without a path. Note that "localhost" is parsed as path.
-	$host = (isset($parts['host']) ? $parts['host'] : '') . (isset($parts['path']) ? $parts['path'] : '');
-	if (strpos(rtrim($host, '/'), '/') !== false) {
-		auth_error(lang('Invalid server or credentials.'));
-	}
-
 	// Check privileged ports.
 	if (isset($parts['port']) && ($parts['port'] < 1024 || $parts['port'] > 65535)) {
 		auth_error(lang('Connecting to privileged ports is not allowed.'));


### PR DESCRIPTION
Removed check to reject server URL path added in version 4.8.4.
The server URL path is required by the Oracle Database service name.

* Example of Server URL : localhost:1521/FREEPDB1