### PR TITLE
Fixed string/query splitting, when \ is at the end of string.

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,33 @@
+```shell
+# Remove previous container
+docker rm -f adminerevo-php-9999
+
+# Start PHP 5.6 container
+docker run \
+	--log-driver local \
+	--name adminerevo-php-9999 \
+	--publish=9999:8000 \
+	--volume ~/Documents/adminerevo:/usr/src/app \
+	--workdir /usr/src/app \
+	--detach \
+	--interactive \
+	--tty \
+	php:8.3-alpine \
+	php -S 0.0.0.0:8000
+
+# Attach shell to PHP container
+docker exec -it adminerevo-php-9999 /bin/sh
+
+# Connect PHP container to a network where DB is
+docker network connect net adminerevo-php-9999
+
+# Install PostgreSQL extensions for PHP
+wget -O - https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions | sh -s pgsql pdo_pgsql
+
+# Restart PHP container
+docker restart adminerevo-php-9999
+```
+
+* On `php:5.6-alpine` prints an error: `Parse error: syntax error, unexpected '?' in /usr/src/app/adminer/include/functions.inc.php on line 502`
+
+* [AdminerEvo](http://localhost:9999/adminer)

--- a/adminer/sql.inc.php
+++ b/adminer/sql.inc.php
@@ -81,7 +81,17 @@ if (!$error && $_POST) {
 					$offset = $pos + strlen($found);
 
 					if ($found && rtrim($found) != $delimiter) { // find matching quote or comment end
-						while (preg_match('(' . ($found == '/*' ? '\*/' : ($found == '[' ? ']' : (preg_match('~^-- |^#~', $found) ? "\n" : preg_quote($found) . "|\\\\."))) . '|$)s', $query, $match, PREG_OFFSET_CAPTURE, $offset)) { //! respect sql_mode NO_BACKSLASH_ESCAPES
+						$c_style = $pos > 0 && substr($query, $pos - 1, 1) == 'E';
+						$pattern = '(' . (
+							$found == '/*'
+								? '\*/'
+								: ($found == '['
+									? ']'
+									: (preg_match('~^-- |^#~', $found)
+										? "\n"
+										: preg_quote($found) . "|\\\\" . ($c_style ? "." : "[^']")))
+						) . '|$)s';
+						while (preg_match($pattern, $query, $match, PREG_OFFSET_CAPTURE, $offset)) { //! respect sql_mode NO_BACKSLASH_ESCAPES
 							$s = $match[0][0];
 							if (!$s && $fp && !feof($fp)) {
 								$query .= fread($fp, 1e5);


### PR DESCRIPTION
Here is the test:

```sql
-- \ at the end of strting query splitting
SELECT 'some''', '\', ';';

SELECT E'some\'', E'\\', E';';

SELECT 'some''', '\', ';', E'some\'', E'\\', E';';

SELECT E'some\'', E'\\', E';', 'some''', '\', ';';
```