### PR TITLE
Fix field selection in ElasticSearch

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -124,7 +124,7 @@ if (isset($_GET["elastic"])) {
 			$data = array();
 			$query = "$table/_search";
 			if ($select != array("*")) {
-				$data["fields"] = $select;
+				$data["fields"] = array_values($select);
 			}
 			if ($order) {
 				$sort = array();


### PR DESCRIPTION
When adding fields to show in the select UI, the select field names do not get increasing numbers but get a "1" appended:
- columns[0][col]
- columns[01][col]
- columns[011][col]

Passing this keys to ElasticSearch leads to an error:
> parsing_exception: Unknown key for a START_OBJECT in [fields].

This patch throws the keys away before sending them to ElasticSearch, which solves the problem.

Resolves: https://github.com/adminerevo/adminerevo/issues/158