### PR TITLE
Allow selecting and searching the _id field in ElasticSearch

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -373,7 +373,14 @@ if (isset($_GET["elastic"])) {
 			}
 		}
 
-		$return = array();
+		$return = array(
+			"_id" => [
+				"field" => "_id",
+				"full_type" => "keyword",
+				"type" => "keyword",
+				"privileges" => array("insert" => 0, "select" => 1, "update" => 0),
+			]
+		);
 		if ($mappings) {
 			foreach ($mappings as $name => $field) {
 				$return[$name] = array(


### PR DESCRIPTION
Show the "_id" field in the "select" and "search" colum lists.

![2024-06-25 elasticsearch _id adminerevo](https://github.com/adminerevo/adminerevo/assets/59036/95015b3c-b708-4a89-903b-0e69112d705c)
