### PR TITLE
Avoid showing version on login page (and css/js version)

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -992,8 +992,14 @@ class Adminer {
 		global $VERSION, $jush, $drivers, $connection;
 		?>
 <h1>
-<?php echo $this->name(); ?> <span class="version"><?php echo $VERSION; ?></span>
-<a href="https://download.adminerevo.org/latest/adminer/"<?php echo target_blank(); ?> id="version" title="<?php echo lang('A newer version of AdminerEvo is available, download it now!'); ?>"><?php echo (version_compare($VERSION, $_COOKIE["adminer_version"]) < 0 ? h($_COOKIE["adminer_version"]) : ""); ?></a>
+    <?php
+    echo $this->name();
+    // Don't show version if not authenticated
+    if ($missing != "auth") {
+        echo ' <span class="version">' . $VERSION . '</span>';
+        echo ' <a href="https://download.adminerevo.org/latest/adminer/"' . target_blank() . ' id="version" title="' . lang('A newer version of AdminerEvo is available, download it now!') . '">' . (version_compare($VERSION, $_COOKIE["adminer_version"]) < 0 ? h($_COOKIE["adminer_version"]) : "") . '</a>';
+    }
+    ?>
 </h1>
 <?php
 		if ($missing == "auth") {

--- a/compile.php
+++ b/compile.php
@@ -195,7 +195,7 @@ function short_identifier($number, $chars) {
 
 // based on http://latrine.dgx.cz/jak-zredukovat-php-skripty
 function php_shrink($input) {
-	global $VERSION;
+	global $VERSION, $random_sha1;
 	$special_variables = array_flip(array('$this', '$GLOBALS', '$_GET', '$_POST', '$_FILES', '$_COOKIE', '$_SESSION', '$_SERVER', '$http_response_header', '$php_errormsg'));
 	$short_variables = array();
 	$shortening = true;
@@ -455,7 +455,7 @@ $file = str_replace('<?php echo script_src("static/editing.js"); ?>' . "\n", "",
 $file = preg_replace('~\s+echo script_src\("\.\./externals/jush/modules/jush-(textarea|txt|js|\$jush)\.js"\);~', '', $file);
 $file = str_replace('<link rel="stylesheet" type="text/css" href="../externals/jush/jush.css">' . "\n", "", $file);
 $file = preg_replace_callback("~compile_file\\('([^']+)'(?:, '([^']*)')?\\)~", 'compile_file', $file); // integrate static files
-$replace = 'preg_replace("~\\\\\\\\?.*~", "", ME) . "?file=\1&version=' . $VERSION . '"';
+$replace = 'preg_replace("~\\\\\\\\?.*~", "", ME) . "?file=\1&version=' . $random_sha1 . '"';
 $file = preg_replace('~\.\./adminer/static/(default\.css|favicon\.ico)~', '<?php echo h(' . $replace . '); ?>', $file);
 $file = preg_replace('~"\.\./adminer/static/(functions\.js)"~', $replace, $file);
 $file = preg_replace('~\.\./adminer/static/([^\'"]*)~', '" . h(' . $replace . ') . "', $file);

--- a/compile.php
+++ b/compile.php
@@ -4,6 +4,9 @@ function adminer_errors($errno, $errstr) {
 	return !!preg_match('~^(Trying to access array offset on value of type null|Undefined array key)~', $errstr);
 }
 
+// A random sha1 hash to avoid caching
+$random_sha1 = sha1(microtime());
+
 error_reporting(6135); // errors and warnings
 set_error_handler('adminer_errors', E_WARNING);
 include dirname(__FILE__) . "/adminer/include/version.inc.php";


### PR DESCRIPTION
As shown in https://github.com/adminerevo/adminerevo/security/advisories/GHSA-mg8h-j64r-v6rm
I removed the version on the login page. I also remove version info in CSS and JS require strings (version=xxx)

No version on login:
![image](https://github.com/user-attachments/assets/beb84634-4b9b-4d2d-8245-7935cfd9953a)

No CSS/JS version info:
![image](https://github.com/user-attachments/assets/b68e8ddd-564c-435c-8f0a-4d0bc24b4421)

