### PR TITLE
Fix server URL validation for Oracle connections

### DIFF
--- a/adminer/drivers/elastic.inc.php
+++ b/adminer/drivers/elastic.inc.php
@@ -234,7 +234,14 @@ if (isset($_GET["elastic"])) {
 		}
 	}
 
-
+	/**
+	 * @param string $hostPath
+	 * @return bool
+	 */
+	function is_server_host_valid($hostPath)
+	{
+		return strpos(rtrim($hostPath, '/'), '/') === false;
+	}
 
 	function connect() {
 		global $adminer;

--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -167,7 +167,14 @@ if (isset($_GET["oracle"])) {
 		}
 	}
 
-
+	/**
+	 * @param string $hostPath
+	 * @return bool
+	 */
+	function is_server_host_valid($hostPath) {
+		// EasyConnect host+path format: host[/[service_name][:server_type][/instance_name]]
+		return (bool)preg_match('~^[^/]+(/([^/:]+)?(:[^/:]+)?(/[^/:]+)?)?$~', $hostPath);
+	}
 
 	function idf_escape($idf) {
 		return '"' . str_replace('"', '""', $idf) . '"';

--- a/adminer/include/auth.inc.php
+++ b/adminer/include/auth.inc.php
@@ -35,15 +35,28 @@ function validate_server_input() {
 		auth_error(lang('Invalid server or credentials.'));
 	}
 
-	// Allow only host without a path. Note that "localhost" is parsed as path.
-	$host = (isset($parts['host']) ? $parts['host'] : '') . (isset($parts['path']) ? $parts['path'] : '');
-	if (strpos(rtrim($host, '/'), '/') !== false) {
+	// Note that "localhost" and IP address without a scheme is parsed as a path.
+	$hostPath = (isset($parts['host']) ? $parts['host'] : '') . (isset($parts['path']) ? $parts['path'] : '');
+
+	// Validate host.
+	if (!is_server_host_valid($hostPath)) {
 		auth_error(lang('Invalid server or credentials.'));
 	}
 
 	// Check privileged ports.
 	if (isset($parts['port']) && ($parts['port'] < 1024 || $parts['port'] > 65535)) {
 		auth_error(lang('Connecting to privileged ports is not allowed.'));
+	}
+}
+
+if (!function_exists('is_server_host_valid')) {
+	/**
+	 * @param string $hostPath
+	 * @return bool
+	 */
+	function is_server_host_valid($hostPath)
+	{
+		return strpos($hostPath, '/') === false;
 	}
 }
 

--- a/plugins/drivers/clickhouse.php
+++ b/plugins/drivers/clickhouse.php
@@ -240,6 +240,15 @@ if (isset($_GET["clickhouse"])) {
 		return apply_queries("DROP TABLE", $tables);
 	}
 
+	/**
+	 * @param string $hostPath
+	 * @return bool
+	 */
+	function is_server_host_valid($hostPath)
+	{
+		return strpos(rtrim($hostPath, '/'), '/') === false;
+	}
+
 	function connect() {
 		global $adminer;
 		$connection = new Min_DB;

--- a/plugins/drivers/simpledb.php
+++ b/plugins/drivers/simpledb.php
@@ -280,7 +280,14 @@ if (isset($_GET["simpledb"])) {
 
 	}
 
-
+	/**
+	 * @param string $hostPath
+	 * @return bool
+	 */
+	function is_server_host_valid($hostPath)
+	{
+		return strpos(rtrim($hostPath, '/'), '/') === false;
+	}
 
 	function connect() {
 		global $adminer;


### PR DESCRIPTION
Every driver can validate URL host and path by its own rules. Path is forbidden by default, HTTP-based drivers allow only '/' as path and Oracle driver validates path according to the EasyConnect URL format.