### PR TITLE
Add Elasticsearch regexp support

### DIFF
--- a/adminer/db.inc.php
+++ b/adminer/db.inc.php
@@ -65,7 +65,7 @@ if ($adminer->homepage()) {
 				}
 				echo "</div></fieldset>\n";
 				if ($_POST["search"] && $_POST["query"] != "") {
-					$_GET["where"][0]["op"] = $adminer->operator_regexp === null || empty($_POST['regexp']) ? $driver->convertOperator("LIKE %%") : $adminer->operator_regexp;
+					$_GET["where"][0]["op"] = $adminer->operator_regexp !== null && !empty($_POST['regexp']) ? $adminer->operator_regexp : $adminer->operator_like;
 					search_tables();
 				}
 			}

--- a/adminer/db.inc.php
+++ b/adminer/db.inc.php
@@ -61,7 +61,7 @@ if ($adminer->homepage()) {
 				echo " <input type='submit' name='search' value='" . lang('Search') . "'>\n";
 				if ($adminer->operator_regexp !== null) {
 					echo "<p><label><input type='checkbox' name='regexp' value='1'" . (empty($_POST['regexp']) ? '' : ' checked') . '>' . lang('as a regular expression') . '</label>';
-					echo doc_link(array('sql' => 'regexp.html', 'pgsql' => 'functions-matching.html#FUNCTIONS-POSIX-REGEXP')) . "</p>\n";
+					echo doc_link(array('sql' => 'regexp.html', 'pgsql' => 'functions-matching.html#FUNCTIONS-POSIX-REGEXP', 'elastic' => 'regexp-syntax.html')) . "</p>\n";
 				}
 				echo "</div></fieldset>\n";
 				if ($_POST["search"] && $_POST["query"] != "") {

--- a/adminer/drivers/mongo.inc.php
+++ b/adminer/drivers/mongo.inc.php
@@ -741,6 +741,7 @@ if (isset($_GET["mongo"])) {
 			'possible_drivers' => array("mongo", "mongodb"),
 			'jush' => "mongo",
 			'operators' => $operators,
+			'operator_like' => "LIKE %%", // TODO: LIKE operator is not listed in operators.
 			'operator_regexp' => $operator_regexp,
 			'functions' => array(),
 			'grouping' => array(),

--- a/adminer/drivers/mssql.inc.php
+++ b/adminer/drivers/mssql.inc.php
@@ -664,6 +664,7 @@ WHERE sys1.xtype = 'TR' AND sys2.name = " . q($table)
 			'structured_types' => $structured_types,
 			'unsigned' => array(),
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL"),
+			'operator_like' => "LIKE %%",
 			'functions' => array("distinct", "len", "lower", "round", "upper"),
 			'grouping' => array("avg", "count", "count distinct", "max", "min", "sum"),
 			'edit_functions' => array(

--- a/adminer/drivers/mysql.inc.php
+++ b/adminer/drivers/mysql.inc.php
@@ -1160,8 +1160,9 @@ if (!defined("DRIVER")) {
 			'structured_types' => $structured_types,
 			'unsigned' => array("unsigned", "zerofill", "unsigned zerofill"), ///< @var array number variants
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "REGEXP", "IN", "FIND_IN_SET", "IS NULL", "NOT LIKE", "NOT REGEXP", "NOT IN", "IS NOT NULL", "SQL"), ///< @var array operators used in select
-			'functions' => array("char_length", "date", "distinct", "from_unixtime", "unix_timestamp", "lower", "round", "floor", "ceil", "sec_to_time", "time_to_sec", "upper"), ///< @var array functions used in select
+			'operator_like' => "LIKE %%",
 			'operator_regexp' => 'REGEXP',
+			'functions' => array("char_length", "date", "distinct", "from_unixtime", "unix_timestamp", "lower", "round", "floor", "ceil", "sec_to_time", "time_to_sec", "upper"), ///< @var array functions used in select
 			'grouping' => array("avg", "count", "count distinct", "group_concat", "max", "min", "sum"), ///< @var array grouping functions used in select
 			'edit_functions' => array( ///< @var array of array("$type|$type2" => "$function/$function2") functions used in editing, [0] - edit and insert, [1] - edit only
 				array(

--- a/adminer/drivers/oracle.inc.php
+++ b/adminer/drivers/oracle.inc.php
@@ -530,6 +530,7 @@ ORDER BY PROCESS
 			'structured_types' => $structured_types,
 			'unsigned' => array(),
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT REGEXP", "NOT IN", "IS NOT NULL", "SQL"),
+			'operator_like' => "LIKE %%",
 			'functions' => array("distinct", "length", "lower", "round", "upper"),
 			'grouping' => array("avg", "count", "count distinct", "max", "min", "sum"),
 			'edit_functions' => array(

--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -910,6 +910,7 @@ AND typelem = 0"
 			'structured_types' => $structured_types,
 			'unsigned' => array(),
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "~", "~*", "!~", "!~*", "LIKE", "LIKE %%", "ILIKE", "ILIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL"), // no "SQL" to avoid CSRF
+			'operator_like' => "LIKE %%",
 			'operator_regexp' => '~*',
 			'functions' => array("char_length", "distinct", "lower", "round", "to_hex", "to_timestamp", "upper"),
 			'grouping' => array("avg", "count", "count distinct", "max", "min", "sum"),

--- a/adminer/drivers/sqlite.inc.php
+++ b/adminer/drivers/sqlite.inc.php
@@ -793,6 +793,7 @@ if (isset($_GET["sqlite"]) || isset($_GET["sqlite2"])) {
 			'structured_types' => array_keys($types),
 			'unsigned' => array(),
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL", "SQL"), // REGEXP can be user defined function
+			'operator_like' => "LIKE %%",
 			'functions' => array("distinct", "hex", "length", "lower", "round", "unixepoch", "upper"),
 			'grouping' => array("avg", "count", "count distinct", "group_concat", "max", "min", "sum"),
 			'edit_functions' => array(

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -3,7 +3,11 @@
 
 class Adminer {
 	/** @var array operators used in select, null for all operators */
-	var $operators;
+	var $operators = null;
+	/** @var string operator for LIKE condition */
+	var $operator_like = null;
+	/** @var string operator for regular expression condition */
+	var $operator_regexp = null;
 
 	/** Name in title and navigation
 	* @return string HTML code

--- a/adminer/include/bootstrap.inc.php
+++ b/adminer/include/bootstrap.inc.php
@@ -92,12 +92,14 @@ $types = $config['types'];
 $structured_types = $config['structured_types'];
 $unsigned = $config['unsigned'];
 $operators = $config['operators'];
-$operator_regexp = isset($config['operator_regexp']) && in_array($config['operator_regexp'], $operators) ? $config['operator_regexp'] : null;
+$operator_like = $config['operator_like'];
+$operator_regexp = $config['operator_regexp'];
 $functions = $config['functions'];
 $grouping = $config['grouping'];
 $edit_functions = $config['edit_functions'];
 if ($adminer->operators === null) {
 	$adminer->operators = $operators;
+	$adminer->operator_like = $operator_like;
 	$adminer->operator_regexp = $operator_regexp;
 }
 

--- a/adminer/include/driver.inc.php
+++ b/adminer/include/driver.inc.php
@@ -151,14 +151,6 @@ function get_driver($id) {
 		return $idf;
 	}
 
-	/** Convert operator so it can be used in search
-	 * @param string $operator
-	 * @return string
-	 */
-	function convertOperator($operator) {
-		return $operator;
-	}
-
 	/** Convert value returned by database to actual value
 	* @param string
 	* @param array

--- a/adminer/include/editing.inc.php
+++ b/adminer/include/editing.inc.php
@@ -540,6 +540,7 @@ function doc_link($paths, $text = "<sup>?</sup>") {
 		'pgsql' => "https://www.postgresql.org/docs/$version/",
 		'mssql' => "https://msdn.microsoft.com/library/",
 		'oracle' => "https://www.oracle.com/pls/topic/lookup?ctx=db" . preg_replace('~^.* (\d+)\.(\d+)\.\d+\.\d+\.\d+.*~s', '\1\2', $server_info) . "&id=",
+		'elastic' => "https://www.elastic.co/guide/en/elasticsearch/reference/$version/",
 	);
 	if (preg_match('~MariaDB~', $server_info)) {
 		$urls['sql'] = "https://mariadb.com/kb/en/library/";

--- a/editor/include/adminer.inc.php
+++ b/editor/include/adminer.inc.php
@@ -1,6 +1,8 @@
 <?php
 class Adminer {
 	var $operators = array("<=", ">=");
+	var $operator_like = null;
+	var $operator_regexp = null;
 	var $_values = array();
 
 	function name() {

--- a/plugins/drivers/clickhouse.php
+++ b/plugins/drivers/clickhouse.php
@@ -427,6 +427,7 @@ if (isset($_GET["clickhouse"])) {
 			'structured_types' => $structured_types,
 			'unsigned' => array(),
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "~", "!~", "LIKE", "LIKE %%", "IN", "IS NULL", "NOT LIKE", "NOT IN", "IS NOT NULL", "SQL"),
+			'operator_like' => "LIKE %%",
 			'functions' => array(),
 			'grouping' => array("avg", "count", "count distinct", "max", "min", "sum"),
 			'edit_functions' => array(),

--- a/plugins/drivers/elastic.php
+++ b/plugins/drivers/elastic.php
@@ -265,10 +265,6 @@ if (isset($_GET["elastic"])) {
 
 			return $this->_conn->affected_rows;
 		}
-
-		function convertOperator($operator) {
-			return $operator == "LIKE %%" ? "should" : $operator;
-		}
 	}
 
 	function connect() {
@@ -581,6 +577,7 @@ if (isset($_GET["elastic"])) {
 			'possible_drivers' => array("json + allow_url_fopen"),
 			'jush' => "elastic",
 			'operators' => array("=", "must", "should", "must_not"),
+			'operator_like' => "should",
 			'functions' => array(),
 			'grouping' => array(),
 			'edit_functions' => array(array("json")),

--- a/plugins/drivers/elastic5.php
+++ b/plugins/drivers/elastic5.php
@@ -267,10 +267,6 @@ if (isset($_GET["elastic5"])) {
 
 			return $this->_conn->affected_rows;
 		}
-
-		function convertOperator($operator) {
-			return $operator == "LIKE %%" ? "should" : $operator;
-		}
 	}
 
 	/**
@@ -561,6 +557,7 @@ if (isset($_GET["elastic5"])) {
 			'possible_drivers' => array("json + allow_url_fopen"),
 			'jush' => "elastic",
 			'operators' => array("=", "must", "should", "must_not"),
+			'operator_like' => "should",
 			'functions' => array(),
 			'grouping' => array(),
 			'edit_functions' => array(array("json")),

--- a/plugins/drivers/elastic5.php
+++ b/plugins/drivers/elastic5.php
@@ -154,28 +154,12 @@ if (isset($_GET["elastic5"])) {
 			foreach ($where as $val) {
 				if (preg_match('~^\((.+ OR .+)\)$~', $val, $matches)) {
 					$parts = explode(" OR ", $matches[1]);
-					$terms = array();
-					foreach ($parts as $part) {
-						list($col, $op, $val) = explode(" ", $part, 3);
-						$term = array($col => $val);
-						if ($op == "=") {
-							$terms[] = array("term" => $term);
-						} elseif (in_array($op, array("must", "should", "must_not"))) {
-							$data["query"]["bool"][$op][]["match"] = $term;
-						}
-					}
 
-					if (!empty($terms)) {
-						$data["query"]["bool"]["filter"][]["bool"]["should"] = $terms;
+					foreach ($parts as $part) {
+						$this->addQueryCondition($part, $data);
 					}
 				} else {
-					list($col, $op, $val) = explode(" ", $val, 3);
-					$term = array($col => $val);
-					if ($op == "=") {
-						$data["query"]["bool"]["filter"][] = array("term" => $term);
-					} elseif (in_array($op, array("must", "should", "must_not"))) {
-						$data["query"]["bool"][$op][]["match"] = $term;
-					}
+					$this->addQueryCondition($val, $data);
 				}
 			}
 
@@ -216,6 +200,33 @@ if (isset($_GET["elastic5"])) {
 			}
 
 			return new Min_Result($return);
+		}
+
+		private function addQueryCondition($val, &$data)
+		{
+			list($col, $op, $val) = explode(" ", $val, 3);
+
+			if (!preg_match('~^([^(]+)\(([^)]+)\)$~', $op, $matches)) {
+				return;
+			}
+			$queryType = $matches[1]; // must, should, must_not
+			$matchType = $matches[2]; // term, match, regexp
+
+			if ($matchType == "regexp") {
+				$data["query"]["bool"][$queryType][] = [
+					"regexp" => [
+						$col => [
+							"value" => $val,
+							"flags" => "ALL",
+							"case_insensitive" => true,
+						]
+					]
+				];
+			} else {
+				$data["query"]["bool"][$queryType][] = [
+					$matchType => [$col => $val]
+				];
+			}
 		}
 
 		function update($type, $record, $queryWhere, $limit = 0, $separator = "\n") {
@@ -427,15 +438,13 @@ if (isset($_GET["elastic5"])) {
 		$return = array(
 			"_id" => array(
 				"field" => "_id",
-				"full_type" => "text",
-				"type" => "text",
+				"full_type" => "_id",
+				"type" => "_id",
 				"privileges" => array("insert" => 1, "select" => 1, "where" => 1, "order" => 1),
 			)
 		);
 
 		foreach ($mappings as $name => $field) {
-			if (isset($field["index"]) && !$field["index"]) continue;
-
 			$return[$name] = array(
 				"field" => $name,
 				"full_type" => $field["type"],
@@ -544,9 +553,9 @@ if (isset($_GET["elastic5"])) {
 		$structured_types = array();
 
 		foreach (array(
-			lang('Numbers') => array("long" => 3, "integer" => 5, "short" => 8, "byte" => 10, "double" => 20, "float" => 66, "half_float" => 12, "scaled_float" => 21),
+			lang('Numbers') => array("long" => 3, "integer" => 5, "short" => 8, "byte" => 10, "double" => 20, "float" => 66, "half_float" => 12, "scaled_float" => 21, "boolean" => 1),
 			lang('Date and time') => array("date" => 10),
-			lang('Strings') => array("string" => 65535, "text" => 65535),
+			lang('Strings') => array("string" => 65535, "text" => 65535, "keyword" => 65535),
 			lang('Binary') => array("binary" => 255),
 		) as $key => $val) {
 			$types += $val;
@@ -556,8 +565,13 @@ if (isset($_GET["elastic5"])) {
 		return array(
 			'possible_drivers' => array("json + allow_url_fopen"),
 			'jush' => "elastic",
-			'operators' => array("=", "must", "should", "must_not"),
-			'operator_like' => "should",
+			'operators' => array(
+				"must(term)", "must(match)", "must(regexp)",
+				"should(term)", "should(match)", "should(regexp)",
+				"must_not(term)", "must_not(match)", "must_not(regexp)",
+			),
+			'operator_like' => "should(match)",
+			'operator_regexp' => "should(regexp)",
 			'functions' => array(),
 			'grouping' => array(),
 			'edit_functions' => array(array("json")),

--- a/plugins/drivers/firebird.php
+++ b/plugins/drivers/firebird.php
@@ -20,7 +20,7 @@ if (isset($_GET["firebird"])) {
 			;
 
 			function connect($server, $username, $password) {
-				$this->_link = ibase_connect($server, $username, $password); 
+				$this->_link = ibase_connect($server, $username, $password);
 				if ($this->_link) {
 					$url_parts = explode(':', $server);
 					$this->service_link = ibase_service_attach($url_parts[0], $username, $password);
@@ -109,9 +109,9 @@ if (isset($_GET["firebird"])) {
 		}
 
 	}
-	
-	
-	
+
+
+
 	class Min_Driver extends Min_SQL {
 	}
 
@@ -140,7 +140,7 @@ if (isset($_GET["firebird"])) {
 	}
 
 	function limit($query, $where, $limit, $offset = 0, $separator = " ") {
-		$return = ''; 
+		$return = '';
 		$return .= ($limit !== null ? $separator . "FIRST $limit" . ($offset ? " SKIP $offset" : "") : "");
 		$return .= " $query$where";
 		return $return;
@@ -171,7 +171,7 @@ if (isset($_GET["firebird"])) {
 		while ($row = ibase_fetch_assoc($result)) {
 				$return[$row['RDB$RELATION_NAME']] = 'table';
 		}
-		ksort($return);	
+		ksort($return);
 		return $return;
 	}
 
@@ -316,6 +316,7 @@ ORDER BY RDB$INDEX_SEGMENTS.RDB$FIELD_POSITION';
 			'possible_drivers' => array("interbase"),
 			'jush' => "firebird",
 			'operators' => array("="),
+			'operator_like' => "LIKE %%", // TODO: LIKE operator is not listed in operators.
 			'functions' => array(),
 			'grouping' => array(),
 			'edit_functions' => array(),

--- a/plugins/drivers/simpledb.php
+++ b/plugins/drivers/simpledb.php
@@ -530,6 +530,7 @@ if (isset($_GET["simpledb"])) {
 			'possible_drivers' => array("SimpleXML + allow_url_fopen"),
 			'jush' => "simpledb",
 			'operators' => array("=", "<", ">", "<=", ">=", "!=", "LIKE", "LIKE %%", "IN", "IS NULL", "NOT LIKE", "IS NOT NULL"),
+			'operator_like' => "LIKE %%",
 			'functions' => array(),
 			'grouping' => array("count"),
 			'edit_functions' => array(array("json")),


### PR DESCRIPTION
- Define `LIKE%%` operator in each driver so it can be properly configured in Elastic drivers.
- New condition operators as a combination of query type and match type.
- Support for regexp in global search.
- Proper formatting of boolean values.