### PR TITLE
Bugfix: Table loses class 'active' in 'edit' screen. Vscode added in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /editor*.php
 /vendor/
 /.idea
+/.vscode

--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -1130,7 +1130,7 @@ bodyLoad('<?php echo (is_object($connection) ? preg_replace('~^(\d\.?\d).*~s', '
 				;
 				echo (support("table") || support("indexes")
 					? '<a href="' . h(ME) . 'table=' . urlencode($table) . '"'
-						. bold(in_array($table, array($_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"], $_GET["select"])), (is_view($status) ? "view" : "structure"))
+						. bold(in_array($table, array($_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"], $_GET["select"], $_GET["edit"])), (is_view($status) ? "view" : "structure"))
 						. " title='" . lang('Show structure') . "'>$name</a>"
 					: "<span>$name</span>"
 				) . "\n";


### PR DESCRIPTION
In adminer, you have a tablelist on the left part of the screen. I know that views are shown there also, but I'll refer then by 'tablelist' for the sake of simplicity.

When the user click in one of these tables, adminer opens a kind of 'table control panel' where you can select data, edit sctructure, modify indexes and so on.

In the specific case when user is seeing/modifying a registry in EDIT screen (where de fields are presented verticaly), the selected table that owns that registry, loses the css class that makes it appeared highlighed from the other tables in tablelist.

This modification, keep table's 'active' css even in the edit screen.

This modifications was tested/debugged in Vscode, so it was added in .ignorelist