### PR TITLE
select original by default for nullable enum

### DIFF
--- a/adminer/include/adminer.inc.php
+++ b/adminer/include/adminer.inc.php
@@ -727,7 +727,7 @@ class Adminer {
 			$selected = $value;
 			if (isset($_GET["select"])) {
 				$options[-1] = lang('original');
-				if ($selected === null) {
+				if ($selected === null || $selected === false) {
 					$selected = -1;
 				}
 			}


### PR DESCRIPTION
The default `$value` passed to `editInput` from `edit_form` for multi-row edits is `false`, not `null`.

Fixes https://github.com/adminerevo/adminerevo/issues/172
It was broken by commit 55d40f85639b586cc82e5123df255895c74e5b7b, so it works fine in v4.8.3